### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 **Empower your AI agents with direct access to the official ClinicalTrials.gov database!**
 
+<a href="https://glama.ai/mcp/servers/@cyanheads/clinicaltrialsgov-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cyanheads/clinicaltrialsgov-mcp-server/badge" alt="ClinicalTrials.gov Server MCP server" />
+</a>
+
 An MCP (Model Context Protocol) server providing a robust, developer-friendly interface to the official [ClinicalTrials.gov v2 API](https://clinicaltrials.gov/data-api/api). Enables LLMs and AI agents to search, retrieve, and analyze clinical study data programmatically.
 
 Built on the [`cyanheads/mcp-ts-template`](https://github.com/cyanheads/mcp-ts-template), this server follows a modular architecture with robust error handling, logging, and security features.


### PR DESCRIPTION
This PR adds a badge for the [ClinicalTrials.gov MCP Server](https://glama.ai/mcp/servers/@cyanheads/clinicaltrialsgov-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cyanheads/clinicaltrialsgov-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cyanheads/clinicaltrialsgov-mcp-server/badge" alt="ClinicalTrials.gov Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.